### PR TITLE
Handle changes to `ace_medical_engine_fnc_getHitpointArmor` in ACE 3.16

### DIFF
--- a/functions/fn_initUnit.sqf
+++ b/functions/fn_initUnit.sqf
@@ -42,7 +42,7 @@ _unit setVariable [
 			if (AAA_VAR_FORCE_BASE_ARMOR) then {
 				_hitpointArmor = AAA_VAR_BASE_ARMOR_VALUE;
 			} else {
-				_hitpointArmor = AAA_VAR_BASE_ARMOR_VALUE + ([_unit, _hitPoint] call ace_medical_engine_fnc_getHitpointArmor);
+				_hitpointArmor = AAA_VAR_BASE_ARMOR_VALUE + (([_unit, _hitPoint] call ace_medical_engine_fnc_getHitpointArmor) param [0]);
 			};
 			// Hitpoint damage to be added by this calculation
 			private _addedDamage = _damage - _prevDamage;


### PR DESCRIPTION
ref https://github.com/acemod/ACE3/blob/master/addons/medical_engine/functions/fnc_getHitpointArmor.sqf#L50
function now returns a tuple of `[_armor, _armorScaled]` in ACE 3.16.0
using `param [0]` will handle this change, but also be backwards compatible with current versions of ace
