### PR TITLE
Update XEH_preInit.sqf for pull request

### DIFF
--- a/XEH_preInit.sqf
+++ b/XEH_preInit.sqf
@@ -173,7 +173,7 @@ private _modName = localize "STR_AAA_Name";
 	"SLIDER",
 	["$STR_AAA_THRESHOLD_VALUE", "$STR_AAA_THRESHOLD_VALUE_Desc"],
 	[_modName, "$STR_AAA_ArmorCoefs"],
-	[0, 50, 0, 2, false],
+	[0, 50, 5, 2, false],
 	1,
 	{},
 	false


### PR DESCRIPTION
Sets default for threshold to 5 to prevent AAA from affecting anything below the skate helmet, since otherwise even underwear will get buffed.  Current scaling I've come up with gives skate helmet a slight buff but still not enough to stop point blank 9mm usually.